### PR TITLE
 Add excludeCharacters option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ var map = require('map-obj')
 var snakeCase = require('to-snake-case')
 
 module.exports = function (obj, options) {
-  options = Object.assign({ deep: true, exclude: [] }, options)
+  options = Object.assign({ deep: true, exclude: [], excludeCharacters: [] }, options)
 
   return map(obj, function (key, val) {
     return [
-      matches(options.exclude, key) ? key : snakeCase(key),
+      matches(options.exclude, key) ? key : snakeCaseOptions(options.excludeCharacters, key),
       val
     ]
   }, options)
@@ -20,4 +20,14 @@ function matches (patterns, value) {
       ? pattern === value
       : pattern.test(value)
   })
+}
+
+function snakeCaseOptions (elements, key) {
+  if (!elements || elements.length <= 0) return snakeCase(key)
+
+  var elementToUse = elements[0]
+  var leftElements = elements.slice(1)
+
+  var subKeys = key.split(elementToUse).map((k) => snakeCaseOptions(leftElements, k))
+  return subKeys.reduce((acc, curr) => `${acc}${acc && acc.length > 0 ? elementToUse : ''}${curr}`, '')
 }

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,15 @@ Default: `[]`
 
 An array of strings or regular expressions matching keys that will be excluded from snake-casing.
 
+###### excludeCharacters
+
+Type: `array[string]`  
+Default: `[]`
+exemple: `['.', '-']`
+
+An array of character elements that will be avoid by the snakecase function.
+exemple : foo-bar.barBaz => foo-bar.bar_baz
+
 ## Related
 
 * [camelcase-keys](https://github.com/sindresorhus/camelcase-keys)

--- a/test.js
+++ b/test.js
@@ -34,3 +34,11 @@ test('exclude', function (t) {
   )
   t.end()
 })
+
+test('exclude Characters', function (t) {
+  t.deepEqual(
+    Snake({ 'fooBar.fooBar': 'baz', 'barBaz.barBaz': 'qux' }, { excludeCharacters: ['.'] }),
+    { 'foo_bar.foo_bar': 'baz', 'bar_baz.bar_baz': 'qux' }
+  )
+  t.end()
+})


### PR DESCRIPTION
I added a new option that permit to avoid some characters from the snakecase function like :
foo-bar.barBaz with excludeCharaters: ['.', '-'] will be foo-bar.bar_baz