### PR TITLE
Modify the parameter type of the snakecaseKeys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,9 @@ Convert object keys to snake using [`to-snake-case`](https://github.com/ianstorm
 @param input - Object or array of objects to snake-case.
 */
 declare function snakecaseKeys(
-  input: ReadonlyArray<{ [key: string]: unknown }>,
+  input: ReadonlyArray<unknown>,
   options?: snakecaseKeys.Options,
-): Array<{ [key: string]: unknown }>;
+): unknown[];
 declare function snakecaseKeys(
   input: { [key: string]: unknown },
   options?: snakecaseKeys.Options,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import { expectType } from 'tsd';
 import camelcaseKeys = require('.');
 
-expectType<Array<{ [key: string]: unknown }>>(
+expectType<unknown[]>(
   camelcaseKeys([{ 'foo-bar': true }]),
 );
 


### PR DESCRIPTION
```typescript
const arr = [1, 2, 3];
snakecaseKeys(arr); // it worked
```