### PR TITLE
Typescript: make inputs generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,12 +18,12 @@ declare namespace snakecaseKeys {
 Convert object keys to snake using [`to-snake-case`](https://github.com/ianstormtaylor/to-snake-case).
 @param input - Object or array of objects to snake-case.
 */
-declare function snakecaseKeys(
-  input: ReadonlyArray<{ [key: string]: unknown }>,
+declare function snakecaseKeys<T>(
+  input: ReadonlyArray<T>,
   options?: snakecaseKeys.Options,
 ): Array<{ [key: string]: unknown }>;
-declare function snakecaseKeys(
-  input: { [key: string]: unknown },
+declare function snakecaseKeys<T>(
+  input: T,
   options?: snakecaseKeys.Options,
 ): { [key: string]: unknown };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,15 @@
 import { expectType } from 'tsd';
 import camelcaseKeys = require('.');
 
+interface TestInterface {
+  foo: boolean
+}
+
+const test: TestInterface = { foo: false }
+expectType<{ [key: string]: unknown }>(
+  camelcaseKeys(test)
+)
+
 expectType<Array<{ [key: string]: unknown }>>(
   camelcaseKeys([{ 'foo-bar': true }]),
 );


### PR DESCRIPTION
This allows any strongly typed interface to be the input to this package without causing type errors.
The prior definition only allowed untyped objects and arrays as inputs.