### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare namespace snakecaseKeys {
   interface Options {
     /**
 		Recurse nested objects and objects in arrays.
-		@default false
+		@default true
 		*/
     readonly deep?: boolean;
 


### PR DESCRIPTION
The index.d.ts claims in a comment that the default value for options.deep is `false`, while the index.js has it as `true`. This fixes the comment