### PR TITLE
Make return type value generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
 - '8'
 - '10'
+- '12'

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,13 +18,13 @@ declare namespace snakecaseKeys {
 Convert object keys to snake using [`to-snake-case`](https://github.com/ianstormtaylor/to-snake-case).
 @param input - Object or array of objects to snake-case.
 */
-declare function snakecaseKeys<T>(
-  input: ReadonlyArray<T>,
-  options?: snakecaseKeys.Options,
-): Array<{ [key: string]: unknown }>;
-declare function snakecaseKeys<T>(
+declare function snakecaseKeys<T extends ReadonlyArray<{ [key: string]: any }>>(
   input: T,
   options?: snakecaseKeys.Options,
-): { [key: string]: unknown };
+): T;
+declare function snakecaseKeys<T extends { [key: string]: any }>(
+  input: T,
+  options?: snakecaseKeys.Options,
+): T;
 
 export = snakecaseKeys;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,42 +1,28 @@
 import {expectType} from 'tsd';
 import snakecaseKeys = require('.');
 
-const fooBarObject = {'foo-bar': true};
+const fooBarObject = {'fooBar': true};
 const camelFooBarObject = snakecaseKeys(fooBarObject);
 expectType<typeof fooBarObject>(camelFooBarObject);
 
-expectType<Array<{ [key: string]: unknown }>>(
-  snakecaseKeys([{ 'foo-bar': true }]),
-);
-
-expectType<{ [key: string]: unknown }>(snakecaseKeys({ 'foo-bar': true }));
-
-expectType<{ [key: string]: unknown }>(
-  snakecaseKeys({ 'foo-bar': true }, { deep: true }),
-);
-
-expectType<{ [key: string]: unknown }>(
-  snakecaseKeys({ 'foo-bar': true }, { exclude: ['foo', /bar/] }),
-);
-
-const fooBarArray = [{'foo-bar': true}];
+const fooBarArray = [{'fooBar': true}];
 const camelFooBarArray = snakecaseKeys(fooBarArray);
 expectType<typeof fooBarArray>(camelFooBarArray);
 
-expectType<Array<{[key in 'foo-bar']: true}>>(snakecaseKeys([{'foo-bar': true}]));
+expectType<Array<{[key in 'fooBar']: true}>>(snakecaseKeys([{'fooBar': true}]));
 
 expectType<string[]>(snakecaseKeys(['name 1', 'name 2']));
 
 expectType<string[]>(snakecaseKeys(['name 1', 'name 2'], {deep: true}));
 
-expectType<{[key in 'foo-bar']: true}>(snakecaseKeys({'foo-bar': true}));
+expectType<{[key in 'fooBar']: true}>(snakecaseKeys({'fooBar': true}));
 
-expectType<{[key in 'foo-bar']: true}>(
-	snakecaseKeys({'foo-bar': true}, {deep: true}),
+expectType<{[key in 'fooBar']: true}>(
+	snakecaseKeys({'fooBar': true}, {deep: true}),
 );
 
-expectType<{[key in 'foo-bar']: true}>(
-  snakecaseKeys({'foo-bar': true}, {exclude: ['foo', /bar/]}),
+expectType<{[key in 'fooBar']: true}>(
+	snakecaseKeys({'fooBar': true}, {exclude: ['foo', /bar/]}),
 );
 
 interface SomeObject {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,14 +1,9 @@
-import { expectType } from 'tsd';
+import {expectType} from 'tsd';
 import snakecaseKeys = require('.');
 
-interface TestInterface {
-  foo: boolean
-}
-
-const test: TestInterface = { foo: false }
-expectType<{ [key: string]: unknown }>(
-  snakecaseKeys(test)
-)
+const fooBarObject = {'foo-bar': true};
+const camelFooBarObject = snakecaseKeys(fooBarObject);
+expectType<typeof fooBarObject>(camelFooBarObject);
 
 expectType<Array<{ [key: string]: unknown }>>(
   snakecaseKeys([{ 'foo-bar': true }]),
@@ -23,3 +18,45 @@ expectType<{ [key: string]: unknown }>(
 expectType<{ [key: string]: unknown }>(
   snakecaseKeys({ 'foo-bar': true }, { exclude: ['foo', /bar/] }),
 );
+
+const fooBarArray = [{'foo-bar': true}];
+const camelFooBarArray = snakecaseKeys(fooBarArray);
+expectType<typeof fooBarArray>(camelFooBarArray);
+
+expectType<Array<{[key in 'foo-bar']: true}>>(snakecaseKeys([{'foo-bar': true}]));
+
+expectType<string[]>(snakecaseKeys(['name 1', 'name 2']));
+
+expectType<string[]>(snakecaseKeys(['name 1', 'name 2'], {deep: true}));
+
+expectType<{[key in 'foo-bar']: true}>(snakecaseKeys({'foo-bar': true}));
+
+expectType<{[key in 'foo-bar']: true}>(
+	snakecaseKeys({'foo-bar': true}, {deep: true}),
+);
+
+expectType<{[key in 'foo-bar']: true}>(
+  snakecaseKeys({'foo-bar': true}, {exclude: ['foo', /bar/]}),
+);
+
+interface SomeObject {
+	someProperty: string;
+}
+
+const someObj: SomeObject = {
+	someProperty: 'this should work'
+};
+
+expectType<SomeObject>(snakecaseKeys(someObj));
+expectType<SomeObject[]>(snakecaseKeys([someObj]));
+
+type SomeTypeAlias = {
+	someProperty: string;
+}
+
+const objectWithTypeAlias = {
+	someProperty: 'this should also work'
+};
+
+expectType<SomeTypeAlias>(snakecaseKeys(objectWithTypeAlias));
+expectType<SomeTypeAlias[]>(snakecaseKeys([objectWithTypeAlias]));


### PR DESCRIPTION
**Changes:**

- The current type definition doesn't allow generics: `Type '{ [key: string]: unknown; }' is not assignable to type 'T'.` Make the return type generic which makes something like this possible. It preserves the input type. 

  ```ts
  export function toSnakeCase<T>(obj: any): T {
    return snakecaseKeys(obj, { deep: true });
  }
  ```

- The key of an object should be a string and the type definition should not care about the value. Because the return type returns `unknown`, this is not allowed. The fix is to change `{ [key: string]: unknown }` to `{ [key: string]: any }`.

  ```ts
  const a = snakecaseKeys({ 'foo' : { 'bar': 'hello' } }, { deep: true });
  console.log(a.foo.bar) //  error TS2571: Object is of type 'unknown'
  ```

These changes completely align with [camelcase-keys](https://github.com/sindresorhus/camelcase-keys) API and has the same test cases as done here 👉 https://github.com/sindresorhus/camelcase-keys/blob/master/index.test-d.ts


