### PR TITLE
ts: export default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,4 +28,4 @@ declare function snakecaseKeys<
   Input extends { [key: string]: any } = { [key: string]: any }
 >(input: Input, options?: snakecaseKeys.Options): ReturnValue;
 
-export = snakecaseKeys;
+export default snakecaseKeys;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectError, expectType } from "tsd";
-import snakecaseKeys = require(".");
+import snakecaseKeys from ".";
 
 // Without generic parameter
 const fooBarObject = { fooBar: true };

--- a/readme.md
+++ b/readme.md
@@ -13,18 +13,18 @@ $ npm install --save snakecase-keys
 ## Usage
 
 ```js
-var snakeCaseKeys = require('snakecase-keys')
+var snakecaseKeys = require('snakecase-keys')
 
-snakeCaseKeys({fooBar: 'baz'})
+snakecaseKeys({fooBar: 'baz'})
 //=> {foo_bar: 'baz'}
 
-snakeCaseKeys({'foo-bar': true, nested: {fooBaz: 'bar'}});
+snakecaseKeys({'foo-bar': true, nested: {fooBaz: 'bar'}});
 //=> {foo_bar: true, nested: {foo_baz: 'bar'}}
 ```
 
 ## API
 
-#### `snakeCaseKeys(obj, options)` -> `object`
+#### `snakecaseKeys(obj, options)` -> `object`
 
 ##### obj
 


### PR DESCRIPTION
Allow `import snakecaseKeys from "."`. This will require https://www.typescriptlang.org/tsconfig#esModuleInterop or similar configuration that treats `module.exports = fn` the same way as `export default fn`.

Closes #44