### PR TITLE
Use same defaults arguments in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,8 +44,8 @@ Convert keys of an object to snake-case strings.
 */
 export type SnakeCaseKeys<
   T extends Record<string, any> | readonly any[],
-  Deep extends boolean,
-  Exclude extends readonly unknown[],
+  Deep extends boolean = true,
+  Exclude extends readonly unknown[] = EmptyTuple,
   Path extends string = ""
 > = T extends readonly any[]
   ? // Handle arrays or tuples.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -42,35 +42,27 @@ expectType<{ foo_bar: boolean; barBaz: true }>(
 // Verify exported type `SnakeCaseKeys`
 // Object
 const objectInput = { fooBar: true };
-expectType<SnakeCaseKeys<typeof objectInput, true, []>>(
-  snakecaseKeys(objectInput)
-);
-expectAssignable<SnakeCaseKeys<{ [key: string]: boolean }, true, []>>(
+expectType<SnakeCaseKeys<typeof objectInput>>(snakecaseKeys(objectInput));
+expectAssignable<SnakeCaseKeys<{ [key: string]: boolean }>>(
   snakecaseKeys(objectInput)
 );
 
 // Array
 const arrayInput = [{ fooBar: true }];
-expectType<SnakeCaseKeys<typeof arrayInput, true, []>>(
-  snakecaseKeys([{ fooBar: true }])
-);
-expectAssignable<SnakeCaseKeys<typeof arrayInput, true, []>>(
-  snakecaseKeys(arrayInput)
-);
-expectType<SnakeCaseKeys<string[], true, []>>(
-  snakecaseKeys(["name 1", "name 2"])
-);
+expectType<SnakeCaseKeys<typeof arrayInput>>(snakecaseKeys([{ fooBar: true }]));
+expectAssignable<SnakeCaseKeys<typeof arrayInput>>(snakecaseKeys(arrayInput));
+expectType<SnakeCaseKeys<string[]>>(snakecaseKeys(["name 1", "name 2"]));
 
 // Deep
 const deepInput = { foo_bar: { "foo-bar": { "foo bar": true } } };
 expectType<SnakeCaseKeys<typeof deepInput, false, []>>(
   snakecaseKeys(deepInput, { deep: false })
 );
-expectType<SnakeCaseKeys<typeof deepInput, true, []>>(
+expectType<SnakeCaseKeys<typeof deepInput>>(
   snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { deep: true })
 );
 const deepArrayInput = [{ "foo-bar": { foo_bar: true } }];
-expectType<SnakeCaseKeys<typeof deepArrayInput, true, []>>(
+expectType<SnakeCaseKeys<typeof deepArrayInput>>(
   snakecaseKeys([{ "foo-bar": { foo_bar: true } }], { deep: true })
 );
 


### PR DESCRIPTION
This adds the same default argument specified when calling `snakeCaseKeys` in the type definitions

It simplifies the use of the exported type 

```
import type { SnakeCaseKeys } from 'snake case-keys';

type myCamelCaseData = { fooBar: string };

// current required type use
type MyCustomTypeAlias = SnakeCaseKeys<myCamelCaseData, true, []>

// simplified required type use
type MyCustomTypeAlias = SnakeCaseKeys<myCamelCaseData>

```