### PR TITLE
types: Export types in a way compatible with TypeScript `"module": "nodenext"`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,4 +105,4 @@ declare function snakecaseKeys<
   WithDefault<Options["exclude"], EmptyTuple>
 >;
 
-export default snakecaseKeys;
+export = snakecaseKeys;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,38 +35,38 @@ type AppendPath<S extends string, Last extends string> = S extends ""
   ? Last
   : `${S}.${Last}`;
 
-/**
-Convert keys of an object to snake-case strings.
-@template T - Input object or array.
-@template Deep - Deep conversion flag.
-@template Exclude - Excluded keys.
-@template Path - Path of keys.
-*/
-export type SnakeCaseKeys<
-  T extends Record<string, any> | readonly any[],
-  Deep extends boolean = true,
-  Exclude extends readonly unknown[] = EmptyTuple,
-  Path extends string = ""
-> = T extends readonly any[]
-  ? // Handle arrays or tuples.
-    {
-      [P in keyof T]: SnakeCaseKeys<T[P], Deep, Exclude>;
-    }
-  : T extends Record<string, any>
-  ? // Handle objects.
-    {
-      [P in keyof T as [Includes<Exclude, P>] extends [true]
-        ? P
-        : SnakeCase<P>]: [Deep] extends [true]
-        ? T[P] extends Record<string, any>
-          ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
-          : T[P]
-        : T[P];
-    }
-  : // Return anything else as-is.
-    T;
-
 declare namespace snakecaseKeys {
+  /**
+  Convert keys of an object to snake-case strings.
+  @template T - Input object or array.
+  @template Deep - Deep conversion flag.
+  @template Exclude - Excluded keys.
+  @template Path - Path of keys.
+  */
+  export type SnakeCaseKeys<
+    T extends Record<string, any> | readonly any[],
+    Deep extends boolean = true,
+    Exclude extends readonly unknown[] = EmptyTuple,
+    Path extends string = ""
+  > = T extends readonly any[]
+    ? // Handle arrays or tuples.
+      {
+        [P in keyof T]: SnakeCaseKeys<T[P], Deep, Exclude>;
+      }
+    : T extends Record<string, any>
+    ? // Handle objects.
+      {
+        [P in keyof T as [Includes<Exclude, P>] extends [true]
+          ? P
+          : SnakeCase<P>]: [Deep] extends [true]
+          ? T[P] extends Record<string, any>
+            ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
+            : T[P]
+          : T[P];
+      }
+    : // Return anything else as-is.
+      T;
+
   interface Options {
     /**
 		Recurse nested objects and objects in arrays.
@@ -99,7 +99,7 @@ declare function snakecaseKeys<
 >(
   input: T,
   options?: Options
-): SnakeCaseKeys<
+): snakecaseKeys.SnakeCaseKeys<
   T,
   WithDefault<Options["deep"], true>,
   WithDefault<Options["exclude"], EmptyTuple>


### PR DESCRIPTION
Thanks for maintaining this useful package!

Because the code in `index.js` uses a commonjs-style `module.exports = function ...` while `index.d.ts` uses an ESM-style `export default ...`, the type of the default export is not interpreted as desired when using TypeScript 4.7 with config `"module": "node16"` (also known as `nodenext`, which is currently in RC). This PR suggests using the same style of default export in both places, which works on all versions & settings of TypeScript I have tested.

I have tested this change using both TypeScript 4.7 RC with the new module setting and some of the older module settings, as well as testing with TypeScript 4.6 on the same older module setting choices, and all those cases now correctly interpret the type of the default export. I also tested to make sure that the type `SnakeCaseKeys` is still exported properly and passing the `tsd` tests.

I ended up chatting with somebody who knows more about this stuff than me in the TypeScript Discord, but here's some additional background reading about the reasons behind this change:
 - https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#commonjs-interop
 - https://github.com/microsoft/TypeScript/issues/48845
 - https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports (Paragraph starting with "Note that using export default")
 - https://stackoverflow.com/a/51238234/3869670