### PR TITLE
Fix optional nested object property keys type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare namespace snakecaseKeys {
         [P in keyof T as [Includes<Exclude, P>] extends [true]
           ? P
           : SnakeCase<P>]: [Deep] extends [true]
-          ? T[P] extends Record<string, any>
+          ? T[P] extends Record<string, any> | undefined
             ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
             : T[P]
           : T[P];
@@ -79,7 +79,7 @@ declare namespace snakecaseKeys {
 		@default []
 		*/
     readonly exclude?: ReadonlyArray<string | RegExp>;
-    
+
     /**
     Options object that gets passed to snake-case parsing function.
     @default {}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -128,6 +128,13 @@ type DeepObjectType = {
       barBaz?: string;
     };
   };
+  optionalFirstLevel?: {
+    fooBar?: string;
+    barBaz?: null;
+    optionalSecondLevel?: {
+      fooBar: number;
+    };
+  };
 };
 type InvalidConvertedDeepObjectDataType = {
   foo_bar?: string;
@@ -139,6 +146,13 @@ type InvalidConvertedDeepObjectDataType = {
     secondLevel?: {
       fooBar: string;
       barBaz?: string;
+    };
+  };
+  optional_first_level?: {
+    fooBar?: string;
+    barBaz?: null;
+    optionalSecondLevel?: {
+      fooBar: number;
     };
   };
 };
@@ -154,7 +168,35 @@ type ConvertedDeepObjectDataType = {
       barBaz?: string;
     };
   };
+  optional_first_level?: {
+    fooBar?: string;
+    barBaz?: null;
+    optionalSecondLevel?: {
+      fooBar: number;
+    };
+  };
 };
+type ConvertedDeepObjectDataTypeDeeply = {
+  foo_bar?: string;
+  bar_baz?: string;
+  baz: string;
+  first_level: {
+    foo_bar?: string;
+    bar_baz?: string;
+    second_level: {
+      foo_bar: string;
+      bar_baz?: string;
+    };
+  };
+  optional_first_level?: {
+    foo_bar?: string;
+    bar_baz?: null;
+    optional_second_level?: {
+      foo_bar: number;
+    };
+  };
+};
+
 const deepInputData: DeepObjectType = {
   fooBar: "fooBar",
   baz: "baz",
@@ -170,6 +212,10 @@ expectType<ConvertedDeepObjectDataType>(
 );
 expectNotType<InvalidConvertedDeepObjectDataType>(
   snakecaseKeys(deepInputData, { deep: false })
+);
+
+expectType<ConvertedDeepObjectDataTypeDeeply>(
+  snakecaseKeys(deepInputData, { deep: true })
 );
 
 // Exclude


### PR DESCRIPTION
Close #76 

Fixed type `SnakeCaseKeys` so that the keys of optional object (nested) properties are snake_case.