### PR TITLE
types: TypeScript 4.8 compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,9 @@ declare namespace snakecaseKeys {
   > = T extends readonly any[]
     ? // Handle arrays or tuples.
       {
-        [P in keyof T]: SnakeCaseKeys<T[P], Deep, Exclude>;
+        [P in keyof T]: T[P] extends Record<string, any> | readonly any[]
+        ? SnakeCaseKeys<T[P], Deep, Exclude>
+        : T[P];
       }
     : T extends Record<string, any>
     ? // Handle objects.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "standard": "^17.0.0",
     "tape": "^5.0.1",
-    "tsd": "^0.22.0"
+    "tsd": "^0.23.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Updates type definition for TS 4.8 compatibility. 

Approach taken from https://github.com/sindresorhus/camelcase-keys/pull/98

Closes #78, Closes #79 