### PR TITLE
fix: ignore native objects in deep types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,19 +55,21 @@ declare namespace snakecaseKeys {
         ? SnakeCaseKeys<T[P], Deep, Exclude>
         : T[P];
       }
-    : T extends Record<string, any>
-    ? // Handle objects.
-      {
-        [P in keyof T as [Includes<Exclude, P>] extends [true]
-          ? P
-          : SnakeCase<P>]: [Deep] extends [true]
-          ? T[P] extends Record<string, any> | undefined
-            ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
-            : T[P]
-          : T[P];
-      }
-    : // Return anything else as-is.
-      T;
+    : T extends Record<string, Date | Error | RegExp>
+      ? T // Date, Error, and RegExp objects are not converted.
+      : T extends Record<string, any>
+      ? // Handle objects.
+        {
+          [P in keyof T as [Includes<Exclude, P>] extends [true]
+            ? P
+            : SnakeCase<P>]: [Deep] extends [true]
+            ? T[P] extends Record<string, any> | undefined
+              ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
+              : T[P]
+            : T[P];
+        }
+      : // Return anything else as-is.
+        T;
 
   interface Options {
     /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -28,6 +28,15 @@ expectType<{ foo_bar: { foo_bar: { foo_bar: boolean } } }>(
 expectType<{ foo_bar: { foo_bar: boolean } }[]>(
   snakecaseKeys([{ "foo-bar": { foo_bar: true } }], { deep: true })
 );
+expectType<{ date: Date }[]>(
+  snakecaseKeys([{ date: new Date() }], { deep: true })
+);
+expectType<{ regexp: RegExp }[]>(
+  snakecaseKeys([{ regexp: /example/ }], { deep: true })
+);
+expectType<{ error: Error }[]>(
+  snakecaseKeys([{ error: new Error() }], { deep: true })
+);
 
 // Exclude
 expectType<{ foo_bar: boolean; barBaz: true }>(


### PR DESCRIPTION
This ought to fix #92.