### PR TITLE
fix: treat deep:true when deep option is omitted

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,7 @@ declare function snakecaseKeys<
   options?: Options
 ): snakecaseKeys.SnakeCaseKeys<
   T,
-  WithDefault<Options["deep"], true>,
+  Options["deep"] extends boolean ? Options["deep"] : true,
   WithDefault<Options["exclude"], EmptyTuple>
 >;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -38,6 +38,17 @@ expectType<{ error: Error }[]>(
   snakecaseKeys([{ error: new Error() }], { deep: true })
 );
 
+// Deep with defalt(no deep option)
+expectType<{ foo_bar: { foo_bar: { foo_bar: boolean } } }>(
+  snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } })
+);
+expectType<{ foo_bar: { foo_bar: boolean } }[]>(
+  snakecaseKeys([{ "foo-bar": { foo_bar: true } }])
+);
+expectType<{ date: Date }[]>(
+  snakecaseKeys([{ date: new Date() }])
+);
+
 // Exclude
 expectType<{ foo_bar: boolean; barBaz: true }>(
   snakecaseKeys(
@@ -73,6 +84,14 @@ expectType<SnakeCaseKeys<typeof deepInput>>(
 const deepArrayInput = [{ "foo-bar": { foo_bar: true } }];
 expectType<SnakeCaseKeys<typeof deepArrayInput>>(
   snakecaseKeys([{ "foo-bar": { foo_bar: true } }], { deep: true })
+);
+
+// Deep with defalt(no deep option)
+expectType<SnakeCaseKeys<typeof deepInput>>(
+  snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } })
+);
+expectType<SnakeCaseKeys<typeof deepArrayInput>>(
+  snakecaseKeys([{ "foo-bar": { foo_bar: true } }])
 );
 
 // Exclude
@@ -225,6 +244,11 @@ expectNotType<InvalidConvertedDeepObjectDataType>(
 
 expectType<ConvertedDeepObjectDataTypeDeeply>(
   snakecaseKeys(deepInputData, { deep: true })
+);
+
+// Deep with defalt(no deep option)
+expectType<ConvertedDeepObjectDataTypeDeeply>(
+  snakecaseKeys(deepInputData)
 );
 
 // Exclude


### PR DESCRIPTION
This ought to fix https://github.com/bendrucker/snakecase-keys/issues/114.

The implementation is changed to work with the following three patterns.

### 1. no option

```ts
snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } })
```

`Options["deep"]` means to get the type of the deep property from the Options type.
If no argument is set, `Options["deep"]` will be `boolean | undefined` type.
Therefore, `WithDefault<Options["deep"], true>` becomes `boolean` type.

The tuple type Deep will be `[boolean]` does not inherit [true], the following will be of type `T[P]`(does not snake_cased nested object keys).

```ts
[Deep] extends [true] ? T[P] extends Record<string, any> | undefined ? ... : ... : T[P]
```

When we use `Options["deep"] extends boolean ? Options["deep"] : true`, if `Options["deep"]` is `boolean | undefined`, it does not inherit `boolean`, so it becomes `true`.

### 2. no deep option

```ts
snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { exclude: ["foo"] as const })
// or
snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { })
```

In this case, Options["deep"] will be of type `unknow`.
So `WithDefault<Options["deep"], true>` is of type `unknow`, so it is the same as the "1. no option” pattern(the tuple `[unknow]`  does not inherit `[true]`).

Like "1. no option", the type definition is set to `Options["deep"] extends boolean ? Options["deep"] : true`, so that if `Options["deep"]` is `unknown`, it does not inherit `boolean`, so it becomes `true`.

### 3. deep option is false or true

```ts
snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { deep: false })
// or
snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { deep: true })
```

In this case, Options["deep"] will be of type `false` or `true`.
Since `false` or `true` inherits `boolean`, Deep will be `false` or `true`, so the control of conversion to snake_case is as expected.




 