### PR TITLE
fix: object properties or class fields/methods must not convert to snake_case

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,7 @@ import { Options as SnakeCaseOptions } from "snake-case";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type EmptyTuple = [];
-
-type JsonObject = { [Key in string]: JsonValue };
-type JsonObjectOptional = JsonObject | undefined;
-type JsonValue = JsonPrimitive | object | JsonObject | JsonArray | undefined;
-type JsonArray = JsonValue[] | readonly JsonValue[];
+type ObjectOptional = Record<string, unknown> | undefined;
 
 /**
 Return a default type if input type is nil.
@@ -49,24 +45,24 @@ declare namespace snakecaseKeys {
   @template Path - Path of keys.
   */
   export type SnakeCaseKeys<
-    T extends JsonObjectOptional | readonly any[],
+    T extends ObjectOptional | readonly any[],
     Deep extends boolean = true,
     Exclude extends readonly unknown[] = EmptyTuple,
     Path extends string = ""
   > = T extends readonly any[]
     ? // Handle arrays or tuples.
       {
-        [P in keyof T]: T[P] extends JsonObjectOptional | readonly any[]
+        [P in keyof T]: T[P] extends Record<string, unknown> | readonly any[]
         ? SnakeCaseKeys<T[P], Deep, Exclude>
         : T[P];
       }
-    : T extends JsonObject
+    : T extends Record<string, unknown>
       ? // Handle objects.
         {
           [P in keyof T as [Includes<Exclude, P>] extends [true]
             ? P
             : SnakeCase<P>]: [Deep] extends [true]
-            ? T[P] extends JsonObjectOptional | readonly any[]
+            ? T[P] extends ObjectOptional | readonly any[]
               ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
               : T[P]
             : T[P];
@@ -101,7 +97,7 @@ Convert object keys to snake using [`to-snake-case`](https://github.com/ianstorm
 @param options - Options of conversion.
 */
 declare function snakecaseKeys<
-  T extends JsonObject | readonly any[],
+  T extends Record<string, unknown> | readonly any[],
   Options extends snakecaseKeys.Options
 >(
   input: T,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,13 @@
-import { SnakeCase } from "type-fest";
+import { SnakeCase, JsonPrimitive } from "type-fest";
 import { Options as SnakeCaseOptions } from "snake-case";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type EmptyTuple = [];
+
+type JsonObject = { [Key in string]: JsonValue };
+type JsonObjectOptional = JsonObject | undefined;
+type JsonValue = JsonPrimitive | object | JsonObject | JsonArray | undefined;
+type JsonArray = JsonValue[] | readonly JsonValue[];
 
 /**
 Return a default type if input type is nil.
@@ -44,26 +49,24 @@ declare namespace snakecaseKeys {
   @template Path - Path of keys.
   */
   export type SnakeCaseKeys<
-    T extends Record<string, any> | readonly any[],
+    T extends JsonObjectOptional | readonly any[],
     Deep extends boolean = true,
     Exclude extends readonly unknown[] = EmptyTuple,
     Path extends string = ""
   > = T extends readonly any[]
     ? // Handle arrays or tuples.
       {
-        [P in keyof T]: T[P] extends Record<string, any> | readonly any[]
+        [P in keyof T]: T[P] extends JsonObjectOptional | readonly any[]
         ? SnakeCaseKeys<T[P], Deep, Exclude>
         : T[P];
       }
-    : T extends Record<string, Date | Error | RegExp>
-      ? T // Date, Error, and RegExp objects are not converted.
-      : T extends Record<string, any>
+    : T extends JsonObject
       ? // Handle objects.
         {
           [P in keyof T as [Includes<Exclude, P>] extends [true]
             ? P
             : SnakeCase<P>]: [Deep] extends [true]
-            ? T[P] extends Record<string, any> | undefined
+            ? T[P] extends JsonObjectOptional | readonly any[]
               ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
               : T[P]
             : T[P];
@@ -98,7 +101,7 @@ Convert object keys to snake using [`to-snake-case`](https://github.com/ianstorm
 @param options - Options of conversion.
 */
 declare function snakecaseKeys<
-  T extends Record<string, any> | readonly any[],
+  T extends JsonObject | readonly any[],
   Options extends snakecaseKeys.Options
 >(
   input: T,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { SnakeCase, JsonPrimitive } from "type-fest";
+import { SnakeCase } from "type-fest";
 import { Options as SnakeCaseOptions } from "snake-case";
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,50 @@
-import { expectAssignable, expectType, expectNotType } from "tsd";
+import { expectAssignable, expectType, expectNotType, expectError } from "tsd";
 import type { SnakeCaseKeys } from ".";
 import snakecaseKeys from ".";
 
+class Point {
+	x: number;
+	y: number;
+
+	addPoint(point: Point): Point {
+		return new Point(this.x + point.x, this.y + point.y);
+	}
+
+	constructor(x: number, y: number) {
+		this.x = x;
+		this.y = y;
+	}
+}
+const point = new Point(0, 10);
+
+interface Person {
+	firstName: string;
+	lastName: string;
+	age: number;
+}
+
+const person: Person = {
+	firstName: 'firstName',
+	lastName: 'lastName',
+	age: 30
+};
+
 // Object
+expectType<{}>(snakecaseKeys({}));
 expectType<{ foo_bar: boolean }>(snakecaseKeys({ fooBar: true }));
 expectAssignable<{ [key: string]: boolean }>(snakecaseKeys({ fooBar: true }));
 
 expectType<{ foo_bar: boolean }>(snakecaseKeys({ FooBar: true }));
+
+// Object value allow any type
+expectType<{ string_value: string; }>(snakecaseKeys({ stringValue: "stringValue" }));
+expectType<{ number_value: number; }>(snakecaseKeys({ numberValue: 123 }));
+expectType<{ boolean_value: boolean; }>(snakecaseKeys({ booleanValue: true }));
+expectType<{ null_value: null }>(snakecaseKeys({ nullValue: null }));
+expectType<{ undefined_value: undefined }>(snakecaseKeys({ undefinedValue: undefined }));
+expectType<{ object_value: Point }>(snakecaseKeys({ objectValue: point }));
+expectType<{ json_object_value: { foo_bar: Point; }; }>(snakecaseKeys({ jsonObjectValue: { fooBar: point } }));
+expectType<{ json_array_value: { json_object_value: { foo_bar: Point; }; }[]; }>(snakecaseKeys({ jsonArrayValue: [{ jsonObjectValue: { fooBar: point } }] }));
 
 // Array
 expectType<{ foo_bar: boolean }[]>(snakecaseKeys([{ fooBar: true }]));
@@ -16,14 +54,14 @@ expectAssignable<Array<{ [key: string]: boolean }>>(
 expectType<string[]>(snakecaseKeys(["name 1", "name 2"]));
 
 // Deep
-expectType<{ foo_bar: { "foo-bar": { "foo bar": true } } }>(
+expectType< { foo_bar: { "foo-bar": { "foo bar": true; }; }; nested: { pointObject: Point; }; }>(
   snakecaseKeys(
-    { foo_bar: { "foo-bar": { "foo bar": true } } },
+    { foo_bar: { "foo-bar": { "foo bar": true } }, nested: { pointObject: point } },
     { deep: false }
   )
 );
-expectType<{ foo_bar: { foo_bar: { foo_bar: boolean } } }>(
-  snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } } }, { deep: true })
+expectType<{ foo_bar: { foo_bar: { foo_bar: boolean; }; }; nested: { point_object: Point; }; }>(
+  snakecaseKeys({ foo_bar: { "foo-bar": { "foo bar": true } }, nested: { pointObject: point }  }, { deep: true })
 );
 expectType<{ foo_bar: { foo_bar: boolean } }[]>(
   snakecaseKeys([{ "foo-bar": { foo_bar: true } }], { deep: true })
@@ -36,6 +74,15 @@ expectType<{ regexp: RegExp }[]>(
 );
 expectType<{ error: Error }[]>(
   snakecaseKeys([{ error: new Error() }], { deep: true })
+);
+expectType<{ point_object: Point }[]>(
+  snakecaseKeys([{ pointObject: point }], { deep: true })
+);
+expectType<{ person_object: Person }[]>(
+  snakecaseKeys([{ personObject: person }], { deep: true })
+);
+expectType<{ date: Date, person_object: Person }[]>(
+  snakecaseKeys([{ date: new Date(), personObject: person }], { deep: true })
 );
 
 // Deep with defalt(no deep option)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectType, expectNotType, expectError } from "tsd";
+import { expectAssignable, expectType, expectNotType } from "tsd";
 import type { SnakeCaseKeys } from ".";
 import snakecaseKeys from ".";
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -36,16 +36,6 @@ expectAssignable<{ [key: string]: boolean }>(snakecaseKeys({ fooBar: true }));
 
 expectType<{ foo_bar: boolean }>(snakecaseKeys({ FooBar: true }));
 
-// Object value allow any type
-expectType<{ string_value: string; }>(snakecaseKeys({ stringValue: "stringValue" }));
-expectType<{ number_value: number; }>(snakecaseKeys({ numberValue: 123 }));
-expectType<{ boolean_value: boolean; }>(snakecaseKeys({ booleanValue: true }));
-expectType<{ null_value: null }>(snakecaseKeys({ nullValue: null }));
-expectType<{ undefined_value: undefined }>(snakecaseKeys({ undefinedValue: undefined }));
-expectType<{ object_value: Point }>(snakecaseKeys({ objectValue: point }));
-expectType<{ json_object_value: { foo_bar: Point; }; }>(snakecaseKeys({ jsonObjectValue: { fooBar: point } }));
-expectType<{ json_array_value: { json_object_value: { foo_bar: Point; }; }[]; }>(snakecaseKeys({ jsonArrayValue: [{ jsonObjectValue: { fooBar: point } }] }));
-
 // Array
 expectType<{ foo_bar: boolean }[]>(snakecaseKeys([{ fooBar: true }]));
 expectAssignable<Array<{ [key: string]: boolean }>>(
@@ -84,6 +74,9 @@ expectType<{ person_object: Person }[]>(
 expectType<{ date: Date, person_object: Person }[]>(
   snakecaseKeys([{ date: new Date(), personObject: person }], { deep: true })
 );
+expectType<{ foo_bar: { foo_baz: { foo_bar: Point; }[]; }[]; }>(
+  snakecaseKeys({ fooBar: [{ fooBaz: [{ fooBar: point }] }] }, { deep: true })
+);
 
 // Deep with defalt(no deep option)
 expectType<{ foo_bar: { foo_bar: { foo_bar: boolean } } }>(
@@ -94,6 +87,9 @@ expectType<{ foo_bar: { foo_bar: boolean } }[]>(
 );
 expectType<{ date: Date }[]>(
   snakecaseKeys([{ date: new Date() }])
+);
+expectType<{ foo_bar: { foo_baz: { foo_bar: Point; }[]; }[]; }>(
+  snakecaseKeys({ fooBar: [{ fooBaz: [{ fooBar: point }] }] })
 );
 
 // Exclude


### PR DESCRIPTION
This ought to fix https://github.com/bendrucker/snakecase-keys/issues/116.

I think the reason why even fields/methods of classes and object are converted to snake_case is because of the use of `Record<string, any>`.
`Record<string, any>` means `{ [P in string]: any; }`. This type definition uses `any`, so it will be `true` as follows.

```ts
// type result is 'true'(Date extends Record<string, any>)
type result = Date extends Record<string, any> ? 'true' : 'false';
```

Therefore, I think the problem can be solved by not using `Record<string, any>` and using `{ [Key in string]: JsonValue }` instead.
