### PR TITLE
require that inputs be plain objects (or arrays of)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,14 +47,14 @@ declare namespace snakecaseKeys {
   @template Path - Path of keys.
   */
   export type SnakeCaseKeys<
-    T extends ObjectUnion | readonly any[],
+    T extends ObjectUnion | ReadonlyArray<Record<string, unknown>>,
     Deep extends boolean = true,
     Exclude extends readonly unknown[] = EmptyTuple,
     Path extends string = ""
-  > = T extends readonly any[]
+  > = T extends ReadonlyArray<Record<string, unknown>>
     ? // Handle arrays or tuples.
       {
-        [P in keyof T]: T[P] extends Record<string, unknown> | readonly any[]
+        [P in keyof T]: T[P] extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>
         ? SnakeCaseKeys<T[P], Deep, Exclude>
         : T[P];
       }
@@ -64,7 +64,7 @@ declare namespace snakecaseKeys {
           [P in keyof T as [Includes<Exclude, P>] extends [true]
             ? P
             : SnakeCase<P>]: [Deep] extends [true]
-            ? T[P] extends ObjectUnion | readonly any[]
+            ? T[P] extends ObjectUnion | ReadonlyArray<Record<string, unknown>>
               ? SnakeCaseKeys<T[P], Deep, Exclude, AppendPath<Path, P & string>>
               : T[P]
             : T[P];
@@ -99,7 +99,7 @@ Convert object keys to snake using [`to-snake-case`](https://github.com/ianstorm
 @param options - Options of conversion.
 */
 declare function snakecaseKeys<
-  T extends Record<string, unknown> | readonly any[],
+  T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>,
   Options extends snakecaseKeys.Options
 >(
   input: T,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ const map = require('map-obj')
 const { snakeCase } = require('snake-case')
 
 module.exports = function (obj, options) {
+  if (Array.isArray(obj) && obj.some(item => item.constructor !== Object)) { throw new Error('obj must be array of plain objects') }
+  if (obj.constructor !== Object) throw new Error('obj must be an plain object')
+
   options = Object.assign({ deep: true, exclude: [], parsingOptions: {} }, options)
 
   return map(obj, function (key, val) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -41,7 +41,6 @@ expectType<{ foo_bar: boolean }[]>(snakecaseKeys([{ fooBar: true }]));
 expectAssignable<Array<{ [key: string]: boolean }>>(
   snakecaseKeys([{ fooBar: true }])
 );
-expectType<string[]>(snakecaseKeys(["name 1", "name 2"]));
 
 // Deep
 expectType< { foo_bar: { "foo-bar": { "foo bar": true; }; }; nested: { pointObject: Point; }; }>(
@@ -114,7 +113,6 @@ expectAssignable<SnakeCaseKeys<{ [key: string]: boolean }>>(
 const arrayInput = [{ fooBar: true }];
 expectType<SnakeCaseKeys<typeof arrayInput>>(snakecaseKeys([{ fooBar: true }]));
 expectAssignable<SnakeCaseKeys<typeof arrayInput>>(snakecaseKeys(arrayInput));
-expectType<SnakeCaseKeys<string[]>>(snakecaseKeys(["name 1", "name 2"]));
 
 // Deep
 const deepInput = { foo_bar: { "foo-bar": { "foo bar": true } } };

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ snakecaseKeys({'foo-bar': true, nested: {fooBaz: 'bar'}});
 ##### obj
 
 *Required*  
-Type: `Record<string, unknown> | ReadonlyArray<Record<string, unknown>>`
+Type: object | array[object]`
 
 A plain object or array of plain objects to transform into snake case (keys only).
 

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,14 @@ snakecaseKeys({'foo-bar': true, nested: {fooBaz: 'bar'}});
 ##### obj
 
 *Required*  
-Type: `object`
+Type: `Record<string, unknown> | ReadonlyArray<Record<string, unknown>>`
 
-An object to transform into snake case (keys only).
+An `Record<string, unknown>` or `ReadonlyArray<Record<string, unknown>>` to transform into snake case (keys only).
 
 ##### options
 
 *Optional*  
-Type: `object`
+Type: `Options`
 
 ###### deep
 

--- a/readme.md
+++ b/readme.md
@@ -31,12 +31,12 @@ snakecaseKeys({'foo-bar': true, nested: {fooBaz: 'bar'}});
 *Required*  
 Type: `Record<string, unknown> | ReadonlyArray<Record<string, unknown>>`
 
-An `Record<string, unknown>` or `ReadonlyArray<Record<string, unknown>>` to transform into snake case (keys only).
+A plain object or array of plain objects to transform into snake case (keys only).
 
 ##### options
 
 *Optional*  
-Type: `Options`
+Type: `object`
 
 ###### deep
 

--- a/test.js
+++ b/test.js
@@ -55,3 +55,57 @@ test('parsing options', function (t) {
   )
   t.end()
 })
+
+test('not a plain object(primitive value)', function (t) {
+  t.throws(
+    () => Snake(1),
+    { message: 'obj must be an plain object' },
+    'Should throw an error when input is not a plain object'
+  )
+  t.end()
+})
+
+test('not a plain object(function value)', function (t) {
+  t.throws(
+    () => Snake(() => { return 1 }),
+    { message: 'obj must be an plain object' },
+    'Should throw an error when input is not a plain object'
+  )
+  t.end()
+})
+
+test('not a plain object(instance value)', function (t) {
+  t.throws(
+    () => Snake(new Date()),
+    { message: 'obj must be an plain object' },
+    'Should throw an error when input is not a plain object'
+  )
+  t.end()
+})
+
+test('not array of plain objects(primitive value)', function (t) {
+  t.throws(
+    () => Snake([1, { fooBar: 'baz' }]),
+    { message: 'obj must be array of plain objects' },
+    'Should throw an error when input is not an array of plain objects'
+  )
+  t.end()
+})
+
+test('not array of plain objects(function value)', function (t) {
+  t.throws(
+    () => Snake([() => { return 1 }, { fooBar: 'baz' }]),
+    { message: 'obj must be array of plain objects' },
+    'Should throw an error when input is not an array of plain objects'
+  )
+  t.end()
+})
+
+test('not array of plain objects(instance value)', function (t) {
+  t.throws(
+    () => Snake([new Date(), { fooBar: 'baz' }]),
+    { message: 'obj must be array of plain objects' },
+    'Should throw an error when input is not an array of plain objects'
+  )
+  t.end()
+})


### PR DESCRIPTION
This resolves the issue [#121](https://github.com/bendrucker/snakecase-keys/issues/132).

I am updating the README to match the TypeScript type definitions.

Then update `any[]` to `ReadonlyArray<Record<string, unknown>>` to accept only the key-value record type of the array.