### PR TITLE
Add `shouldRecurse` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,13 @@ declare namespace snakecaseKeys {
     readonly exclude?: ReadonlyArray<string | RegExp>;
 
     /**
+    A function that determines whether to recurse for a specific key and value.
+    */
+   readonly shouldRecurse?: {
+    (key: any, value: any): boolean;
+   }
+
+    /**
     Options object that gets passed to snake-case parsing function.
     @default {}
     */

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = function (obj, options) {
   return map(obj, function (key, val) {
     return [
       matches(options.exclude, key) ? key : snakeCase(key, options.parsingOptions),
-      val
+      val,
+      mapperOptions(key, val, options)
     ]
   }, options)
 }
@@ -20,4 +21,10 @@ function matches (patterns, value) {
       ? pattern === value
       : pattern.test(value)
   })
+}
+
+function mapperOptions (key, val, options) {
+  return options.shouldRecurse
+    ? { shouldRecurse: options.shouldRecurse(key, val) }
+    : undefined
 }

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,15 @@ Default: `[]`
 
 An array of strings or regular expressions matching keys that will be excluded from snake-casing.
 
+###### `shouldRecurse(key, val)` -> `boolean`
+
+*Optional*  
+Type: `function`
+
+A function that determines if `val` should be recursed.
+
+Requires `deep: true`.
+
 ## Related
 
 * [camelcase-keys](https://github.com/sindresorhus/camelcase-keys)

--- a/test.js
+++ b/test.js
@@ -55,3 +55,25 @@ test('parsing options', function (t) {
   )
   t.end()
 })
+
+test('shouldRecurse option', function (t) {
+  t.deepEqual(
+    Snake(
+      { fooBar: { barBaz: 'qux' }, nested: { barBaz: 'qux' } },
+      { deep: true, shouldRecurse: (key, val) => key !== 'nested' }
+    ),
+    { foo_bar: { bar_baz: 'qux' }, nested: { barBaz: 'qux' } }
+  )
+  const date = new Date()
+  t.deepEqual(
+    Snake(
+      { fooBar: { barBaz: 'qux' }, fooIcon: date },
+      { deep: true, shouldRecurse: (key, val) => !(val instanceof Date) }
+    ),
+    {
+      foo_bar: { bar_baz: 'qux' },
+      foo_icon: date
+    }
+  )
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -67,12 +67,12 @@ test('shouldRecurse option', function (t) {
   const date = new Date()
   t.deepEqual(
     Snake(
-      { fooBar: { barBaz: 'qux' }, fooIcon: date },
+      { fooBar: { barBaz: 'qux' }, fooDate: date },
       { deep: true, shouldRecurse: (key, val) => !(val instanceof Date) }
     ),
     {
       foo_bar: { bar_baz: 'qux' },
-      foo_icon: date
+      foo_date: date
     }
   )
   t.end()


### PR DESCRIPTION
This pull request adds the `shouldRecurse` option outlined in [this comment](https://github.com/bendrucker/snakecase-keys/issues/71#issuecomment-1121636032) for passing in custom logic for skipping deep-recursion for specific values. Tests, readme and types have been updated to cover the new option. Let me know if there's anything that needs to be addressed and thank you for the library!