### PR TITLE
Replace `Object.constructor` with `{}.constructor`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,15 @@
 const map = require('map-obj')
 const { snakeCase } = require('snake-case')
 
+const PlainObjectConstructor = {}.constructor
+
 module.exports = function (obj, options) {
   if (Array.isArray(obj)) {
-    if (obj.some(item => item.constructor !== Object)) {
+    if (obj.some(item => item.constructor !== PlainObjectConstructor)) {
       throw new Error('obj must be array of plain objects')
     }
   } else {
-    if (obj.constructor !== Object) {
+    if (obj.constructor !== PlainObjectConstructor) {
       throw new Error('obj must be an plain object')
     }
   }


### PR DESCRIPTION
This PR fixes #150. It prevents the `obj must be a plain object` error when `Object.constructor` is overridden.

### Changes:
- Replaced `Object.constructor` with `{}.constructor` to determine if an object is a plain object.
