### PR TITLE
build: bump map-obj from ^4.1.0 to ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "map-obj": "^4.1.0",
+    "map-obj": "^4.2.0",
     "snake-case": "^3.0.4",
     "type-fest": "^4.15.0"
   },


### PR DESCRIPTION
The `shouldRecurse` option introduced in #134 relies on `map-obj`'s `shouldRecurse` option that was released in [v4.2.0][1]. This commit ensures a compatible version of `map-obj`.

[1]: https://github.com/sindresorhus/map-obj/releases/tag/v4.2.0