### PR TITLE
accept custom snake case fn

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,16 @@ declare namespace snakecaseKeys {
       : // Return anything else as-is.
         T;
 
+  /**
+  Convert keys using a custom function - returns generic object type.
+  */
+  export type CustomSnakeCaseKeys<
+    T extends ObjectUnion | ReadonlyArray<Record<string, unknown>>,
+    Deep extends boolean = true
+  > = T extends ReadonlyArray<unknown>
+    ? Array<Record<string, unknown>>
+    : Record<string, unknown>;
+
   interface Options {
     /**
 		Recurse nested objects and objects in arrays.
@@ -97,6 +107,14 @@ declare namespace snakecaseKeys {
     @default {}
     */
     readonly parsingOptions?: SnakeCaseOptions;
+
+    /**
+    Custom function to convert keys to snake case.
+    When provided, TypeScript will return a generic Record<string, unknown> type
+    since the transformation cannot be determined at compile time.
+    @default Built-in snake case conversion
+    */
+    readonly snakeCase?: (key: string) => string;
   }
 }
 
@@ -105,6 +123,17 @@ Convert object keys to snake using [`to-snake-case`](https://github.com/ianstorm
 @param input - Object or array of objects to snake-case.
 @param options - Options of conversion.
 */
+declare function snakecaseKeys<
+  T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>,
+  Options extends snakecaseKeys.Options
+>(
+  input: T,
+  options: Options & { snakeCase: (key: string) => string }
+): snakecaseKeys.CustomSnakeCaseKeys<
+  T,
+  Options["deep"] extends boolean ? Options["deep"] : true
+>;
+
 declare function snakecaseKeys<
   T extends Record<string, unknown> | ReadonlyArray<Record<string, unknown>>,
   Options extends snakecaseKeys.Options

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ module.exports = function (obj, options) {
 
   options = Object.assign({ deep: true, exclude: [], parsingOptions: {} }, options)
 
+  const convertCase = options.snakeCase || ((key) => snakeCase(key, options.parsingOptions))
+
   return map(obj, function (key, val) {
     return [
-      matches(options.exclude, key) ? key : snakeCase(key, options.parsingOptions),
+      matches(options.exclude, key) ? key : convertCase(key),
       val,
       mapperOptions(key, val, options)
     ]

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -331,3 +331,25 @@ const nullCamelcased: SnakeCaseKeys<{fooBar: {fooProp: string} | null}, true>
 expectType<{foo_bar: {foo_prop: string} | null}>(objectCamelcased);
 // eslint-disable-next-line @typescript-eslint/ban-types
 expectType<{foo_bar: {foo_prop: string} | null}>(nullCamelcased);
+
+// Test custom snakeCase function
+const customSnakeCase = (key: string): string => {
+  return key.replace(/([A-Z])/g, '_$1').toLowerCase();
+};
+
+// When using custom function, types become generic Record<string, unknown>
+const customResult = snakecaseKeys({ fooBar: 'test', barBaz: 123 }, { snakeCase: customSnakeCase });
+expectType<Record<string, unknown>>(customResult);
+
+// Test with a custom function that returns uppercase
+const uppercaseConverter = (key: string): string => key.toUpperCase();
+
+const uppercaseResult = snakecaseKeys({ fooBar: true, barBaz: 'test' }, { snakeCase: uppercaseConverter });
+expectType<Record<string, unknown>>(uppercaseResult);
+
+// Test custom snakeCase with deep option and array
+const arrayResult = snakecaseKeys(
+  [{ fooBar: { barBaz: 'test' } }],
+  { snakeCase: (key) => key.replace(/([A-Z])/g, '_$1').toUpperCase(), deep: true }
+);
+expectType<Array<Record<string, unknown>>>(arrayResult);

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,20 @@ A function that determines if `val` should be recursed.
 
 Requires `deep: true`.
 
+###### parsingOptions
+
+Type: `object`  
+Default: `{}`
+
+Options object passed to the built-in `snake-case` parsing function. See [`snake-case`](https://github.com/blakeembrey/change-case/tree/master/packages/snake-case) for available options.
+
+###### snakeCase
+
+*Optional*
+Type: `function(string)` -> `string`
+
+Custom function to convert a key to snake case. Use this to fully override the default behavior of the library and convert keys according to your own conventions. When provided, the return type will be a generic `Record<string, unknown>`, since specific keys cannot be inferred from the custom function.
+
 ## Related
 
 * [camelcase-keys](https://github.com/sindresorhus/camelcase-keys)

--- a/test.js
+++ b/test.js
@@ -138,3 +138,21 @@ test('not array of plain objects(instance value)', function (t) {
   )
   t.end()
 })
+
+test('custom snakeCase function', function (t) {
+  const customSnakeCase = (key) => key.replace(/([A-Z])/g, '_$1').toLowerCase()
+  t.deepEqual(
+    Snake({ fooBar: 'baz', barBaz: 'qux' }, { snakeCase: customSnakeCase }),
+    { foo_bar: 'baz', bar_baz: 'qux' }
+  )
+  t.end()
+})
+
+test('custom snakeCase function with nested objects', function (t) {
+  const customSnakeCase = (key) => key.toUpperCase()
+  t.deepEqual(
+    Snake({ fooBar: { barBaz: 'qux' } }, { snakeCase: customSnakeCase }),
+    { FOOBAR: { BARBAZ: 'qux' } }
+  )
+  t.end()
+})


### PR DESCRIPTION
Allows users to override the `snake-case` package entirely, as an escape hatch for conventions that are not readily implemented via its options. Also adds docs for `parsingOptions`.

When you override the function, the return type will become a plain `Record<string, unknown>`, since the compiler cannot infer the output type. Technically this should apply to `parsingOptions` too and I will make that change in a breaking release. Double technically, there is no guarantee that `type-fest` and `snake-case` agree. But at least that's a bounded problem—worst case I could fork the type and modify it to conform. Whereas user-provided options have no solution for providing compatible types.