### PR TITLE
snake-case -> change-case

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { SnakeCase } from "type-fest";
-import { Options as SnakeCaseOptions } from "snake-case";
+import { Options as SnakeCaseOptions } from "change-case";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type EmptyTuple = [];

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import map from 'map-obj'
-import { snakeCase } from 'snake-case'
+import { snakeCase } from 'change-case'
 
 const PlainObjectConstructor = {}.constructor
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "change-case": "^5.4.4",
     "map-obj": "^5.0.2",
-    "snake-case": "^3.0.4",
     "type-fest": "^4.15.0"
   },
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ $ npm install --save snakecase-keys
 ## Usage
 
 ```js
-var snakecaseKeys = require('snakecase-keys')
+import snakecaseKeys from 'snakecase-keys'
 
 snakecaseKeys({fooBar: 'baz'})
 //=> {foo_bar: 'baz'}
@@ -66,7 +66,16 @@ Requires `deep: true`.
 Type: `object`  
 Default: `{}`
 
-Options object passed to the built-in `snake-case` parsing function. See [`snake-case`](https://github.com/blakeembrey/change-case/tree/master/packages/snake-case) for available options.
+Options object passed to the built-in `snakeCase` function from `change-case`. Available options include:
+
+- `split`: Custom function to split strings into words
+- `locale`: Locale for case conversion
+- `separateNumbers`: Whether to separate numbers (deprecated, use `splitSeparateNumbers`)
+- `delimiter`: Custom delimiter between words
+- `prefixCharacters`: Characters to preserve at start
+- `suffixCharacters`: Characters to preserve at end
+
+See [`change-case`](https://github.com/blakeembrey/change-case) for full documentation.
 
 ###### snakeCase
 

--- a/test.js
+++ b/test.js
@@ -55,9 +55,9 @@ test('exclude', function (t) {
 })
 
 test('parsing options', function (t) {
-  const camelCaseRegex = /([a-z])([A-Z])/g
+  const splitOnCamelCase = input => input.split(/(?=[A-Z])/)
   t.deepEqual(
-    Snake({ 'fooBar.baz': 'qux', 'bar.bazQux': 'foo' }, { parsingOptions: { stripRegexp: camelCaseRegex } }),
+    Snake({ 'fooBar.baz': 'qux', 'bar.bazQux': 'foo' }, { parsingOptions: { split: splitOnCamelCase } }),
     { 'foo_bar.baz': 'qux', 'bar.baz_qux': 'foo' }
   )
   t.end()


### PR DESCRIPTION
`snake-case` merged into `change-case`, from the same author. It has some new options but should generally behave the same.

Closes #157