### PR TITLE
chore: add default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "exports": {
     "import": "./index.js",
+    "default": "./index.js",
     "types": "./index.d.ts"
   },
   "scripts": {


### PR DESCRIPTION
Going from 8 to 9, I got an ERR_PACKAGE_PATH_NOT_EXPORTED error, it seems to be solved by adding a default export.