### PR TITLE
pkg: fix exports order

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "exports": {
     "import": "./index.js",
-    "default": "./index.js",
-    "types": "./index.d.ts"
+    "types": "./index.d.ts",
+    "default": "./index.js"
   },
   "scripts": {
     "test": "standard && tape test.js && tsd"


### PR DESCRIPTION
https://nodejs.org/docs/latest/api/packages.html#conditional-exports

> Within the ["exports"](https://nodejs.org/docs/latest/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries.

Closes #167 